### PR TITLE
fix: 회원가입 로직이 로그인 부분에 잘못 들어간 문제 해결

### DIFF
--- a/Lotte_SweetPatatos_Warr-Cinema/WebContent/member/login.jsp
+++ b/Lotte_SweetPatatos_Warr-Cinema/WebContent/member/login.jsp
@@ -106,8 +106,7 @@
         const form = $(this);
         const url = form.attr('action');
 
-        if (!hasValue($userId.val(), '아이디') || !hasValue($('#password').val(), '비밀번호')
-            || !hasValue($('#userName').val(), '이름') || !hasValue($('#email').val(), '메일 주소')) {
+        if (!hasValue($userId.val(), '아이디') || !hasValue($('#password').val(), '비밀번호')) {
             return;
         }
 

--- a/Lotte_SweetPatatos_Warr-Cinema/WebContent/member/signup.jsp
+++ b/Lotte_SweetPatatos_Warr-Cinema/WebContent/member/signup.jsp
@@ -120,7 +120,9 @@
         const form = $(this);
         const url = form.attr('action');
 
-        if (!hasValue($('#userId').val(), '아이디') || !hasValue($('#password').val(), '비밀번호')) {
+        if (!hasValue($('#userId').val(), '아이디') || !hasValue($('#password').val(), '비밀번호')
+            || !hasValue($('#userName').val(), '이름') || !hasValue($('#email').val(), '메일 주소')
+        ) {
             return;
         }
 


### PR DESCRIPTION
### 설명

- 회원가입에서 수행해야 할 로직이 로그인에 잘못 들어가 로그인이 정상적으로 되지 않는 문제가 있습니다.
- 직접 수정해서 사용하려면,
- login.jsp
```java
$('#loginForm').submit(function (e) {
      e.preventDefault();
      const form = $(this);
      const url = form.attr('action');
      if (!hasValue($userId.val(), '아이디') || !hasValue($('#password').val(), '비밀번호')) {
          return;
      }

      $.ajax({
          type: 'POST',
          url: url,
          data: form.serialize(),
          success: function (data) {
              if (data.loginSuccess) {
                  location.href = '/movie/main.jsp';
                  return
              }
              alert('로그인 정보가 일치하지 않습니다.');
          },
          error: function () {
              console.log('error')
          },
      })
  });
```

- singup.jsp
```java
$('#signupForm').submit(function (e) {
      e.preventDefault();
      const form = $(this);
      const url = form.attr('action');

      if (!hasValue($('#userId').val(), '아이디') || !hasValue($('#password').val(), '비밀번호')
          || !hasValue($('#userName').val(), '이름') || !hasValue($('#email').val(), '메일 주소')
      ) {
          return;
      }

      $.ajax({
          type: 'POST',
          url: url,
          data: form.serialize(),
          success: function (data) {
              if (data.signupSuccess) {
                  location.href = '/member/login.jsp';
                  return
              }
              alert('회원가입에 실패했습니다.');
          },
          error: function () {
              console.log('error')
          },
      });
  });
```

위와 같이 수정해서 테스트하시면 됩니다.